### PR TITLE
Add full stock sell functionality to Portfolio page

### DIFF
--- a/src/main/resources/com/javarepowizards/portfoliomanager/views/portfolio/portfolio.css
+++ b/src/main/resources/com/javarepowizards/portfoliomanager/views/portfolio/portfolio.css
@@ -217,3 +217,17 @@
     -fx-fill: white;
     -fx-font-size: 16px;
 }
+.sell-button {
+    -fx-background-color: #c62828; /* strong red */
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-background-radius: 4px;
+    -fx-font-size: 14px;
+    -fx-padding: 8 20;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.3), 4, 0, 0, 2);
+}
+
+.sell-button:hover {
+    -fx-background-color: #b71c1c; /* darker on hover */
+}
+

--- a/src/main/resources/com/javarepowizards/portfoliomanager/views/portfolio/portfolio.fxml
+++ b/src/main/resources/com/javarepowizards/portfoliomanager/views/portfolio/portfolio.fxml
@@ -148,6 +148,12 @@
                                                 <String fx:value="column-header-background" />
                                             </styleClass>
                                         </TableColumn>
+                                        <TableColumn fx:id="sellCol" prefWidth="75.0" text="Sell">
+                                            <styleClass>
+                                                <String fx:value="column-header" />
+                                                <String fx:value="column-header-background" />
+                                            </styleClass>
+                                        </TableColumn>
                                     </columns>
                                     <VBox.margin>
                                         <Insets top="30.0" />


### PR DESCRIPTION
- Implemented full-sell capability for individual holdings via new 'Sell' column in Portfolio table
- Added sell button to each row in the Portfolio table with full styling using .sell-button class
- Integrated sell action to delete user_holding entries based on selected stock and user ID
- Refreshed pie chart and table upon sell to reflect changes in real time

