### PR TITLE
fix: prevent double-counting of holdings on stock purchase

### DIFF
--- a/src/main/java/com/javarepowizards/portfoliomanager/controllers/stocks/StocksController.java
+++ b/src/main/java/com/javarepowizards/portfoliomanager/controllers/stocks/StocksController.java
@@ -457,7 +457,6 @@ public class StocksController implements Initializable {
                 return;
             }
 
-            portfolioDAO.addToHoldings(entry);
             portfolioDAO.upsertHolding(currentUserId, stockName, quantity, totalValue);
             portfolioDAO.deductFromBalance(currentUserId, totalValue);
 


### PR DESCRIPTION
Removed duplicate call to addToHoldings in StocksController to avoid double upsert. Fixed inflated portfolio value caused by redundant insert logic in addToHoldings and upsertHolding.